### PR TITLE
Add test cases for airtable, oauth, api, and cache modules

### DIFF
--- a/airtable_test.go
+++ b/airtable_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheLinks(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	_, err := airtable.cacheLinks()
+	if err != nil {
+		t.Errorf("cacheLinks() error = %v", err)
+	}
+}
+
+func TestClearDeletedLinks(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	err := airtable.clearDeletedLinks()
+	if err != nil {
+		t.Errorf("clearDeletedLinks() error = %v", err)
+	}
+}
+
+func TestCacheLists(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	_, err := airtable.cacheLists()
+	if err != nil {
+		t.Errorf("cacheLists() error = %v", err)
+	}
+}
+
+func TestClearDeletedLists(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	err := airtable.clearDeletedLists()
+	if err != nil {
+		t.Errorf("clearDeletedLists() error = %v", err)
+	}
+}
+
+func TestCreateLink(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	link := &Link{
+		Name:     "Test Link",
+		Note:     "Test Note",
+		URL:      "http://example.com",
+		Category: "Test Category",
+		Tags:     []string{"Test Tag"},
+		Done:     false,
+		ListIDs:  []string{"Test List ID"},
+	}
+	err := airtable.createLink(link)
+	if err != nil {
+		t.Errorf("createLink() error = %v", err)
+	}
+}
+
+func TestCreateList(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	list := &List{
+		Name: "Test List",
+		Note: "Test Note",
+	}
+	links := []Link{
+		{
+			Name:     "Test Link",
+			Note:     "Test Note",
+			URL:      "http://example.com",
+			Category: "Test Category",
+			Tags:     []string{"Test Tag"},
+			Done:     false,
+			ListIDs:  []string{"Test List ID"},
+		},
+	}
+	err := airtable.createList(list, &links)
+	if err != nil {
+		t.Errorf("createList() error = %v", err)
+	}
+}
+
+func TestUpdateLink(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	link := &Link{
+		ID:       "Test Link ID",
+		Name:     "Updated Test Link",
+		Note:     "Updated Test Note",
+		URL:      "http://example.com",
+		Category: "Updated Test Category",
+		Tags:     []string{"Updated Test Tag"},
+		Done:     false,
+		ListIDs:  []string{"Updated Test List ID"},
+	}
+	err := airtable.updateLink(link)
+	if err != nil {
+		t.Errorf("updateLink() error = %v", err)
+	}
+}
+
+func TestUpdateList(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	list := &List{
+		ID:       "Test List ID",
+		Name:     "Updated Test List",
+		Note:     "Updated Test Note",
+		LinkIDs:  []string{"Updated Test Link ID"},
+	}
+	err := airtable.updateList(list)
+	if err != nil {
+		t.Errorf("updateList() error = %v", err)
+	}
+}
+
+func TestDeleteLink(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	link := &Link{
+		ID: "Test Link ID",
+	}
+	err := airtable.deleteLink(link)
+	if err != nil {
+		t.Errorf("deleteLink() error = %v", err)
+	}
+}
+
+func TestDeleteList(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	list := &List{
+		ID: "Test List ID",
+	}
+	err := airtable.deleteList(list, true)
+	if err != nil {
+		t.Errorf("deleteList() error = %v", err)
+	}
+}
+
+func TestListToLinkCopier(t *testing.T) {
+	airtable := &Airtable{
+		Cache: &Cache{},
+	}
+	list := &List{
+		ID:   "Test List ID",
+		Name: "Test List",
+	}
+	err := airtable.listToLinkCopier(list)
+	if err != nil {
+		t.Errorf("listToLinkCopier() error = %v", err)
+	}
+}

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetchRecords(t *testing.T) {
+	airtable := &Airtable{
+		BaseURL: "https://api.airtable.com/v0",
+		BaseID:  "app1234567890",
+		Auth: &Auth{
+			AccessToken: "test_token",
+		},
+	}
+
+	params := map[string]interface{}{
+		"filterByFormula": "IS_AFTER(LAST_MODIFIED_TIME(),'2022-01-01T00:00:00.000Z')",
+		"fields":          []string{"Name", "Note", "URL", "Category", "Tags", "Last Modified", "Record URL", "Done", "Lists"},
+	}
+
+	records, err := airtable.fetchRecords("Links", params)
+	if err != nil {
+		t.Errorf("fetchRecords() error = %v", err)
+	}
+
+	if len(records) == 0 {
+		t.Errorf("fetchRecords() returned no records")
+	}
+}
+
+func TestFetchSchema(t *testing.T) {
+	airtable := &Airtable{
+		BaseURL: "https://api.airtable.com/v0",
+		BaseID:  "app1234567890",
+		Auth: &Auth{
+			AccessToken: "test_token",
+		},
+		Cache: &Cache{},
+	}
+
+	err := airtable.fetchSchema()
+	if err != nil {
+		t.Errorf("fetchSchema() error = %v", err)
+	}
+
+	tags, _ := airtable.Cache.getData("Tags")
+	if tags == nil || *tags == "" {
+		t.Errorf("fetchSchema() did not cache tags")
+	}
+
+	categories, _ := airtable.Cache.getData("Categories")
+	if categories == nil || *categories == "" {
+		t.Errorf("fetchSchema() did not cache categories")
+	}
+}
+
+func TestCreateRecords(t *testing.T) {
+	airtable := &Airtable{
+		BaseURL: "https://api.airtable.com/v0",
+		BaseID:  "app1234567890",
+		Auth: &Auth{
+			AccessToken: "test_token",
+		},
+	}
+
+	records := []*Record{
+		{
+			Fields: &map[string]interface{}{
+				"Name":     "Test Link",
+				"Note":     "Test Note",
+				"URL":      "http://example.com",
+				"Category": "Test Category",
+				"Tags":     []string{"Test Tag"},
+				"Done":     false,
+				"Lists":    []string{"Test List ID"},
+			},
+		},
+	}
+
+	err := airtable.createRecords("Links", records)
+	if err != nil {
+		t.Errorf("createRecords() error = %v", err)
+	}
+}
+
+func TestUpdateRecords(t *testing.T) {
+	airtable := &Airtable{
+		BaseURL: "https://api.airtable.com/v0",
+		BaseID:  "app1234567890",
+		Auth: &Auth{
+			AccessToken: "test_token",
+		},
+	}
+
+	records := []*Record{
+		{
+			ID: stringPtr("rec1234567890"),
+			Fields: &map[string]interface{}{
+				"Name":     "Updated Test Link",
+				"Note":     "Updated Test Note",
+				"URL":      "http://example.com",
+				"Category": "Updated Test Category",
+				"Tags":     []string{"Updated Test Tag"},
+				"Done":     false,
+				"Lists":    []string{"Updated Test List ID"},
+			},
+		},
+	}
+
+	err := airtable.updateRecords("Links", records)
+	if err != nil {
+		t.Errorf("updateRecords() error = %v", err)
+	}
+}
+
+func TestDeleteRecords(t *testing.T) {
+	airtable := &Airtable{
+		BaseURL: "https://api.airtable.com/v0",
+		BaseID:  "app1234567890",
+		Auth: &Auth{
+			AccessToken: "test_token",
+		},
+	}
+
+	records := []*Record{
+		{
+			ID: stringPtr("rec1234567890"),
+		},
+	}
+
+	err := airtable.deleteRecords("Links", records)
+	if err != nil {
+		t.Errorf("deleteRecords() error = %v", err)
+	}
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetLinks(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+
+	link := Link{
+		Name:         "Test Link",
+		Note:         "Test Note",
+		URL:          "http://example.com",
+		Category:     "Test Category",
+		Tags:         []string{"Test Tag"},
+		Created:      time.Now(),
+		LastModified: time.Now(),
+		RecordURL:    "http://example.com/record",
+		ID:           "Test Link ID",
+		Done:         false,
+		ListIDs:      []string{"Test List ID"},
+	}
+
+	cache.saveLinks([]Link{link})
+
+	links, err := cache.getLinks(nil)
+	if err != nil {
+		t.Errorf("getLinks() error = %v", err)
+	}
+
+	if len(links) != 1 {
+		t.Errorf("getLinks() returned %d links, expected 1", len(links))
+	}
+
+	if links[0].Name != "Test Link" {
+		t.Errorf("getLinks() returned link with name %s, expected 'Test Link'", links[0].Name)
+	}
+}
+
+func TestGetLists(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+
+	list := List{
+		Name:         "Test List",
+		Note:         "Test Note",
+		Created:      time.Now(),
+		LastModified: time.Now(),
+		RecordURL:    "http://example.com/record",
+		ID:           "Test List ID",
+	}
+
+	cache.saveLists([]List{list})
+
+	lists, err := cache.getLists()
+	if err != nil {
+		t.Errorf("getLists() error = %v", err)
+	}
+
+	if len(lists) != 1 {
+		t.Errorf("getLists() returned %d lists, expected 1", len(lists))
+	}
+
+	if lists[0].Name != "Test List" {
+		t.Errorf("getLists() returned list with name %s, expected 'Test List'", lists[0].Name)
+	}
+}
+
+func TestSaveLinks(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+
+	link := Link{
+		Name:         "Test Link",
+		Note:         "Test Note",
+		URL:          "http://example.com",
+		Category:     "Test Category",
+		Tags:         []string{"Test Tag"},
+		Created:      time.Now(),
+		LastModified: time.Now(),
+		RecordURL:    "http://example.com/record",
+		ID:           "Test Link ID",
+		Done:         false,
+		ListIDs:      []string{"Test List ID"},
+	}
+
+	err := cache.saveLinks([]Link{link})
+	if err != nil {
+		t.Errorf("saveLinks() error = %v", err)
+	}
+
+	links, err := cache.getLinks(nil)
+	if err != nil {
+		t.Errorf("getLinks() error = %v", err)
+	}
+
+	if len(links) != 1 {
+		t.Errorf("getLinks() returned %d links, expected 1", len(links))
+	}
+
+	if links[0].Name != "Test Link" {
+		t.Errorf("getLinks() returned link with name %s, expected 'Test Link'", links[0].Name)
+	}
+}
+
+func TestSaveLists(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+
+	list := List{
+		Name:         "Test List",
+		Note:         "Test Note",
+		Created:      time.Now(),
+		LastModified: time.Now(),
+		RecordURL:    "http://example.com/record",
+		ID:           "Test List ID",
+	}
+
+	err := cache.saveLists([]List{list})
+	if err != nil {
+		t.Errorf("saveLists() error = %v", err)
+	}
+
+	lists, err := cache.getLists()
+	if err != nil {
+		t.Errorf("getLists() error = %v", err)
+	}
+
+	if len(lists) != 1 {
+		t.Errorf("getLists() returned %d lists, expected 1", len(lists))
+	}
+
+	if lists[0].Name != "Test List" {
+		t.Errorf("getLists() returned list with name %s, expected 'Test List'", lists[0].Name)
+	}
+}
+
+func TestClearDeletedRecords(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+
+	link := Link{
+		Name:         "Test Link",
+		Note:         "Test Note",
+		URL:          "http://example.com",
+		Category:     "Test Category",
+		Tags:         []string{"Test Tag"},
+		Created:      time.Now(),
+		LastModified: time.Now(),
+		RecordURL:    "http://example.com/record",
+		ID:           "Test Link ID",
+		Done:         false,
+		ListIDs:      []string{"Test List ID"},
+	}
+
+	cache.saveLinks([]Link{link})
+
+	err := cache.clearDeletedRecords("Links", []string{"Test Link ID"})
+	if err != nil {
+		t.Errorf("clearDeletedRecords() error = %v", err)
+	}
+
+	links, err := cache.getLinks(nil)
+	if err != nil {
+		t.Errorf("getLinks() error = %v", err)
+	}
+
+	if len(links) != 1 {
+		t.Errorf("getLinks() returned %d links, expected 1", len(links))
+	}
+
+	err = cache.clearDeletedRecords("Links", []string{})
+	if err != nil {
+		t.Errorf("clearDeletedRecords() error = %v", err)
+	}
+
+	links, err = cache.getLinks(nil)
+	if err != nil {
+		t.Errorf("getLinks() error = %v", err)
+	}
+
+	if len(links) != 0 {
+		t.Errorf("getLinks() returned %d links, expected 0", len(links))
+	}
+}
+
+func TestSetData(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+
+	err := cache.setData("TestKey", "TestValue")
+	if err != nil {
+		t.Errorf("setData() error = %v", err)
+	}
+
+	value, err := cache.getData("TestKey")
+	if err != nil {
+		t.Errorf("getData() error = %v", err)
+	}
+
+	if *value != "TestValue" {
+		t.Errorf("getData() returned %s, expected 'TestValue'", *value)
+	}
+}
+
+func TestGetData(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+
+	cache.setData("TestKey", "TestValue")
+
+	value, err := cache.getData("TestKey")
+	if err != nil {
+		t.Errorf("getData() error = %v", err)
+	}
+
+	if *value != "TestValue" {
+		t.Errorf("getData() returned %s, expected 'TestValue'", *value)
+	}
+}
+
+func TestClearCache(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+
+	link := Link{
+		Name:         "Test Link",
+		Note:         "Test Note",
+		URL:          "http://example.com",
+		Category:     "Test Category",
+		Tags:         []string{"Test Tag"},
+		Created:      time.Now(),
+		LastModified: time.Now(),
+		RecordURL:    "http://example.com/record",
+		ID:           "Test Link ID",
+		Done:         false,
+		ListIDs:      []string{"Test List ID"},
+	}
+
+	cache.saveLinks([]Link{link})
+
+	err := cache.clearCache()
+	if err != nil {
+		t.Errorf("clearCache() error = %v", err)
+	}
+
+	links, err := cache.getLinks(nil)
+	if err != nil {
+		t.Errorf("getLinks() error = %v", err)
+	}
+
+	if len(links) != 0 {
+		t.Errorf("getLinks() returned %d links, expected 0", len(links))
+	}
+}

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestAuth_isValid(t *testing.T) {
+	auth := &Auth{
+		Token: &oauth2.Token{
+			AccessToken: "test_token",
+			Expiry:      time.Now().Add(time.Hour),
+		},
+	}
+	if !auth.isValid() {
+		t.Errorf("Expected token to be valid")
+	}
+
+	auth.Expiry = time.Now().Add(-time.Hour)
+	if auth.isValid() {
+		t.Errorf("Expected token to be invalid")
+	}
+}
+
+func TestAuth_isRefreshValid(t *testing.T) {
+	auth := &Auth{
+		RefreshToken:  "test_refresh_token",
+		RefreshExpiry: &[]time.Time{time.Now().Add(time.Hour)}[0],
+	}
+	if !auth.isRefreshValid() {
+		t.Errorf("Expected refresh token to be valid")
+	}
+
+	auth.RefreshExpiry = &[]time.Time{time.Now().Add(-time.Hour)}[0]
+	if auth.isRefreshValid() {
+		t.Errorf("Expected refresh token to be invalid")
+	}
+}
+
+func TestAuth_read(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+	cache.setData("AccessToken", "test_token")
+	cache.setData("Expiry", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+	cache.setData("RefreshToken", "test_refresh_token")
+	cache.setData("RefreshExpiry", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+
+	auth := &Auth{}
+	auth.read(cache)
+
+	if auth.AccessToken != "test_token" {
+		t.Errorf("Expected AccessToken to be 'test_token', got '%s'", auth.AccessToken)
+	}
+	if auth.RefreshToken != "test_refresh_token" {
+		t.Errorf("Expected RefreshToken to be 'test_refresh_token', got '%s'", auth.RefreshToken)
+	}
+}
+
+func TestAuth_write(t *testing.T) {
+	cache := &Cache{file: ":memory:"}
+	cache.init()
+
+	auth := &Auth{
+		Token: &oauth2.Token{
+			AccessToken: "test_token",
+			Expiry:      time.Now().Add(time.Hour),
+		},
+		RefreshToken:  "test_refresh_token",
+		RefreshExpiry: &[]time.Time{time.Now().Add(time.Hour)}[0],
+	}
+	auth.write(cache)
+
+	accessToken, _ := cache.getData("AccessToken")
+	if *accessToken != "test_token" {
+		t.Errorf("Expected AccessToken to be 'test_token', got '%s'", *accessToken)
+	}
+	refreshToken, _ := cache.getData("RefreshToken")
+	if *refreshToken != "test_refresh_token" {
+		t.Errorf("Expected RefreshToken to be 'test_refresh_token', got '%s'", *refreshToken)
+	}
+}
+
+func TestOAuth_init(t *testing.T) {
+	o := &OAuth{}
+	o.init()
+
+	if o.config.ClientID != os.Getenv("CLIENT_ID") {
+		t.Errorf("Expected ClientID to be '%s', got '%s'", os.Getenv("CLIENT_ID"), o.config.ClientID)
+	}
+	if o.config.RedirectURL != os.Getenv("REDIRECT_URI") {
+		t.Errorf("Expected RedirectURL to be '%s', got '%s'", os.Getenv("REDIRECT_URI"), o.config.RedirectURL)
+	}
+}
+
+func TestOAuth_handleRoot(t *testing.T) {
+	o := &OAuth{authorizationCache: make(map[string]string)}
+	o.init()
+
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(o.handleRoot)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusFound {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusFound)
+	}
+
+	location, err := rr.Result().Location()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if location.Scheme != "https" || location.Host != "www.airtable.com" {
+		t.Errorf("handler returned unexpected location: got %v", location)
+	}
+}
+
+func TestOAuth_handleAirtableOAuth(t *testing.T) {
+	o := &OAuth{
+		authorizationCache: make(map[string]string),
+		authComplete:       make(chan Auth, 1),
+	}
+	o.init()
+
+	state := "test_state"
+	codeVerifier := "test_code_verifier"
+	o.authorizationCache[state] = codeVerifier
+
+	data := url.Values{}
+	data.Set("state", state)
+	data.Set("code", "test_code")
+
+	req, err := http.NewRequest("GET", "/airtable-oauth?"+data.Encode(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(o.handleAirtableOAuth)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+}
+
+func TestOAuth_handleRefresh(t *testing.T) {
+	o := &OAuth{authComplete: make(chan Auth, 1)}
+	o.init()
+
+	data := url.Values{}
+	data.Set("refresh_token", "test_refresh_token")
+
+	req, err := http.NewRequest("GET", "/refresh?"+data.Encode(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(o.handleRefresh)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+}
+
+func TestOAuth_startServer(t *testing.T) {
+	o := &OAuth{}
+	o.init()
+
+	go o.startServer()
+	time.Sleep(1 * time.Second)
+
+	resp, err := http.Get("http://localhost:" + os.Getenv("PORT"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if status := resp.StatusCode; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+}
+
+func TestAirtable_getAuth(t *testing.T) {
+	a := &Airtable{
+		Auth:  &Auth{},
+		Cache: &Cache{file: ":memory:"},
+	}
+	a.Cache.init()
+
+	o := &OAuth{}
+	o.init()
+
+	redirectURL := o.config.RedirectURL
+	u, err := url.Parse(redirectURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseURL := u.Scheme + "://" + u.Host
+
+	auth := Auth{}
+	auth.read(a.Cache)
+	if auth.isValid() {
+		return
+	} else if auth.isRefreshValid() {
+		go o.startServer()
+		resp, err := http.Get(baseURL + "/refresh?refresh_token=" + auth.RefreshToken)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var responseData map[string]interface{}
+		if err := json.Unmarshal(body, &responseData); err != nil {
+			t.Fatal(err)
+		}
+
+		expiry := int64(responseData["expires_in"].(float64)) + time.Now().Unix()
+		RefreshExpiry := int64(responseData["refresh_expires_in"].(float64)) + time.Now().Unix()
+		RefreshExpiryTime := time.Unix(RefreshExpiry, 0)
+
+		newAuth := Auth{
+			Token: &oauth2.Token{
+				AccessToken:  responseData["access_token"].(string),
+				TokenType:    responseData["token_type"].(string),
+				RefreshToken: responseData["refresh_token"].(string),
+				Expiry:       time.Unix(expiry, 0),
+			},
+			RefreshExpiry: &RefreshExpiryTime,
+		}
+		a.Auth = &newAuth
+
+		return
+	}
+
+	go o.startServer()
+	cmd := exec.Command("open", baseURL)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	newAuth := <-o.authComplete
+	newAuth.write(a.Cache)
+	a.Auth = &newAuth
+}


### PR DESCRIPTION
Add test cases for `airtable.go`, `oauth.go`, `api.go`, and `cache.go` modules.

* **airtable_test.go**
  - Add test cases for `cacheLinks`, `clearDeletedLinks`, `cacheLists`, `clearDeletedLists`, `createLink`, `createList`, `updateLink`, `updateList`, `deleteLink`, `deleteList`, and `listToLinkCopier` functions.

* **oauth_test.go**
  - Add test cases for `Auth` struct methods `isValid`, `isRefreshValid`, `read`, and `write`.
  - Add test cases for `OAuth` struct methods `init`, `handleRoot`, `handleAirtableOAuth`, `handleRefresh`, and `startServer`.
  - Add test cases for `Airtable` struct method `getAuth`.

* **api_test.go**
  - Add test cases for `fetchRecords`, `fetchSchema`, `createRecords`, `updateRecords`, and `deleteRecords` functions.

* **cache_test.go**
  - Add test cases for `getLinks`, `getLists`, `saveLinks`, `saveLists`, `clearDeletedRecords`, `setData`, `getData`, and `clearCache` functions.

